### PR TITLE
Fixing upload path for clothing items

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -134,7 +134,7 @@ def add_clothing_item():
     if image and allowed_file(image.filename) and size_limit(image):
         filename = f"{user_id}_{secure_filename(image.filename)}"
 
-        upload_folder = os.path.join(current_app.root_path, 'static', current_app.config['UPLOAD_CLOTHING_ITEM'])
+        upload_folder = os.path.join(current_app.config['UPLOAD_CLOTHING_ITEM'])
         os.makedirs(upload_folder, exist_ok=True)
 
         filepath = os.path.join(upload_folder, filename)


### PR DESCRIPTION
I just delete the current_app.root_path and static to leave only the config for UPLOAD CLOTHING ITEM so now it'll point to app/static/clothing_items

