### PR TITLE
Adding cleanup functions 

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -30,6 +30,8 @@ class User(db.Model, UserMixin):
 
     wardrobe_items = db.relationship('ClothingItem', backref='user', lazy='dynamic', cascade='all, delete-orphan')
     outfits = db.relationship('Outfit', backref='user', lazy='dynamic', cascade='all, delete-orphan')
+    sent_shared = db.relationship('SharedOutfit', foreign_keys='SharedOutfit.sender_id', cascade='all, delete-orphan', backref='sender_user')
+    received_shared = db.relationship('SharedOutfit', foreign_keys='SharedOutfit.receiver_id', cascade='all, delete-orphan', backref='receiver_user')
 
 # ----------------------
 # Clothing Item Model
@@ -82,6 +84,6 @@ class SharedOutfit(db.Model):
     sender_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
     receiver_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
 
-    outfit = db.relationship('Outfit', backref='shared_entries')
-    sender = db.relationship('User', foreign_keys=[sender_id])
-    receiver = db.relationship('User', foreign_keys=[receiver_id])
+    outfit = db.relationship('Outfit', backref=db.backref('shared_entries', cascade='all, delete-orphan'))
+    sender = db.relationship('User', foreign_keys=[sender_id], overlaps="sender_user,sent_shared")
+    receiver = db.relationship('User', foreign_keys=[receiver_id], overlaps="receiver_user,received_shared")

--- a/app/routes.py
+++ b/app/routes.py
@@ -12,6 +12,9 @@ from .utils import (
     generate_reset_token, verify_reset_token, try_to_login,
     send_notification_welcome, send_notification_shared_outfit,
     send_notification_delete,
+    cleanup_clothing_items,
+    cleanup_outfits,
+    cleanup_profile_picture
 )
 from werkzeug.security import generate_password_hash, check_password_hash
 from werkzeug.utils import secure_filename
@@ -604,10 +607,16 @@ def profile():
             return redirect(url_for('main.profile'))
         
         user_email = current_user.email
+        user_id = current_user.id            
+
         try:
+            cleanup_clothing_items(user_id)
+            cleanup_outfits(user_id)
+            cleanup_profile_picture(current_user)
+
             db.session.delete(current_user)
             db.session.commit()
-            
+
             logout_user()
         except Exception as e:
             db.session.rollback()
@@ -615,7 +624,6 @@ def profile():
             flash("Could not delete your account. Please try again", 'error')
             return redirect(url_for('main.profile'))
 
-        logout_user()
         # Send notification of deleting
         try:
             send_notification_delete(user_email)


### PR DESCRIPTION
Adding cleanup functions and properly remove image_path and relationship in database for SharedOutfits

- Now User can delete their account and all their associated Clothing item, Outfits, Profile picture and Shared outfits. Particularly in this change, deleting image from the static folders and adding cascade to relationship of SharedOutfits 